### PR TITLE
Implement basic filter functionality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,31 @@
 find_package(HDF5 REQUIRED)
+find_package(std_compat REQUIRED)
+find_package(LibPressio REQUIRED)
+
+include(CMakePrintHelpers)
+message(HDF5 STUFF:)
+cmake_print_variables(HDF5_LIBRARIES)
+cmake_print_variables(HDF5_INCLUDE_DIRS)
+
+add_library(ROCCI SHARED
+  src/rocci.c
+  src/rocci_ByteToolkit.c
+  src/rocci_FileUtil.c
+)
+target_include_directories(
+  ROCCI
+  PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:ROCCI>
+)
+
+target_link_libraries(
+  ROCCI
+  PUBLIC LibPressio::libpressio
+)
+
 add_library(
-  hdf5rocci
+  hdf5rocci SHARED
   src/H5Z_ROCCI.c
   )
 target_link_libraries(
@@ -25,4 +50,4 @@ install(TARGETS hdf5rocci EXPORT HDF5ROCCI
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   )
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/hdf5_rocci)
-export(TARGETS hdf5rocci FILE HDF5ROCCI.cmake)
+export(TARGETS hdf5rocci ROCCI FILE HDF5ROCCI.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,15 +2,17 @@ find_package(HDF5 REQUIRED)
 find_package(std_compat REQUIRED)
 find_package(LibPressio REQUIRED)
 
-include(CMakePrintHelpers)
-message(HDF5 STUFF:)
-cmake_print_variables(HDF5_LIBRARIES)
-cmake_print_variables(HDF5_INCLUDE_DIRS)
+# include(CMakePrintHelpers)
+# message(HDF5 DIRS:)
+# cmake_print_variables(HDF5_LIBRARIES)
+# cmake_print_variables(HDF5_INCLUDE_DIRS)
 
 add_library(ROCCI SHARED
   src/rocci.c
   src/rocci_ByteToolkit.c
   src/rocci_FileUtil.c
+  src/rocci_utils.c
+  src/inih/ini.c
 )
 target_include_directories(
   ROCCI

--- a/README.md
+++ b/README.md
@@ -36,3 +36,5 @@ Now you can test the filter using the examples `rocciToHDF5` and `drocciFromHDF5
 ./rocciToHDF5 -f testfloat_8_8_128.dat 8 8 128
 ./drocciFromHDF5 testfloat_8_8_128.dat.rocci.h5
 ```
+
+*Note: while the C API usage in the examples above has been confirmed to work with hdf5 1.14.2, using utilities such as h5repack and h5dump may require a different version of hdf5. Currently, we have confirmed that hdf5 1.10.1 works for both the C API and the hdf5 utility scripts*

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ cmake -DBUILD_TESTS=ON ..
 make
 ```
 
+Additionally, we must allow hdf5 to find our custom filter by setting `HDF5_PLUGIN_PATH` to the directory containing `libhdf5rocci.so`:
+
+```bash
+export HDF5_PLUGIN_PATH=/home/projects/h5z-rocci/build
+```
+
 Now you can test the filter using the examples `rocciToHDF5` and `drocciFromHDF5` in `build/test`. To alter the configuration you can alter `rocci.config` in `test/`, this file should be in the working directory when calling the H5Z filter to ensure it is found.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
 # H5Z-ROCCI
 ROCCI: Integrated Cyberinfrastructure for In Situ Lossy Compression Optimization Based on Post Hoc Analysis Requirements
+
+
+# Quickstart with Spack
+First we'll set up a spack environment:
+```bash
+git clone https://github.com/spack/spack
+git clone https://github.com/robertu94/spack_packages robertu94_packages
+source ./spack/share/spack/setup-env.sh
+spack repo add robertu94_packages
+
+spack env create -d rocci_env
+spack env activate rocci_env/
+spack -e rocci_env config add modules:prefix_inspections:lib64:[LD_LIBRARY_PATH]
+spack -e rocci_env config add modules:prefix_inspections:lib:[LD_LIBRARY_PATH]
+spack add libpressio-tools ^ libpressio+sz+zfp+sz3 # add compressor plugins as needed here
+
+spack concretize -f
+spack install
+```
+
+Then we can build H5Z-ROCCI:
+```bash
+git clone https://github.com/roccilab/h5z-rocci.git
+cd h5z-rocci
+mkdir build && cd build/
+cmake -DBUILD_TESTS=ON ..
+make
+```
+
+Now you can test the filter using the examples `rocciToHDF5` and `drocciFromHDF5` in `build/test`. To alter the configuration you can alter `rocci.config` in `test/`, this file should be in the working directory when calling the H5Z filter to ensure it is found.
+
+```bash
+# build/test/
+./rocciToHDF5 -f testfloat_8_8_128.dat 8 8 128
+./drocciFromHDF5 testfloat_8_8_128.dat.rocci.h5
+```

--- a/include/inih/LICENSE.txt
+++ b/include/inih/LICENSE.txt
@@ -1,0 +1,27 @@
+
+The "inih" library is distributed under the New BSD license:
+
+Copyright (c) 2009, Ben Hoyt
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Ben Hoyt nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY BEN HOYT ''AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL BEN HOYT BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/include/inih/ini.h
+++ b/include/inih/ini.h
@@ -1,0 +1,178 @@
+/* inih -- simple .INI file parser
+
+SPDX-License-Identifier: BSD-3-Clause
+
+Copyright (C) 2009-2020, Ben Hoyt
+
+inih is released under the New BSD license (see LICENSE.txt). Go to the project
+home page for more info:
+
+https://github.com/benhoyt/inih
+
+*/
+
+#ifndef INI_H
+#define INI_H
+
+/* Make this header file easier to include in C++ code */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdio.h>
+
+/* Nonzero if ini_handler callback should accept lineno parameter. */
+#ifndef INI_HANDLER_LINENO
+#define INI_HANDLER_LINENO 0
+#endif
+
+/* Visibility symbols, required for Windows DLLs */
+#ifndef INI_API
+#if defined _WIN32 || defined __CYGWIN__
+#	ifdef INI_SHARED_LIB
+#		ifdef INI_SHARED_LIB_BUILDING
+#			define INI_API __declspec(dllexport)
+#		else
+#			define INI_API __declspec(dllimport)
+#		endif
+#	else
+#		define INI_API
+#	endif
+#else
+#	if defined(__GNUC__) && __GNUC__ >= 4
+#		define INI_API __attribute__ ((visibility ("default")))
+#	else
+#		define INI_API
+#	endif
+#endif
+#endif
+
+/* Typedef for prototype of handler function. */
+#if INI_HANDLER_LINENO
+typedef int (*ini_handler)(void* user, const char* section,
+                           const char* name, const char* value,
+                           int lineno);
+#else
+typedef int (*ini_handler)(void* user, const char* section,
+                           const char* name, const char* value);
+#endif
+
+/* Typedef for prototype of fgets-style reader function. */
+typedef char* (*ini_reader)(char* str, int num, void* stream);
+
+/* Parse given INI-style file. May have [section]s, name=value pairs
+   (whitespace stripped), and comments starting with ';' (semicolon). Section
+   is "" if name=value pair parsed before any section heading. name:value
+   pairs are also supported as a concession to Python's configparser.
+
+   For each name=value pair parsed, call handler function with given user
+   pointer as well as section, name, and value (data only valid for duration
+   of handler call). Handler should return nonzero on success, zero on error.
+
+   Returns 0 on success, line number of first error on parse error (doesn't
+   stop on first error), -1 on file open error, or -2 on memory allocation
+   error (only when INI_USE_STACK is zero).
+*/
+INI_API int ini_parse(const char* filename, ini_handler handler, void* user);
+
+/* Same as ini_parse(), but takes a FILE* instead of filename. This doesn't
+   close the file when it's finished -- the caller must do that. */
+INI_API int ini_parse_file(FILE* file, ini_handler handler, void* user);
+
+/* Same as ini_parse(), but takes an ini_reader function pointer instead of
+   filename. Used for implementing custom or string-based I/O (see also
+   ini_parse_string). */
+INI_API int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
+                     void* user);
+
+/* Same as ini_parse(), but takes a zero-terminated string with the INI data
+instead of a file. Useful for parsing INI data from a network socket or
+already in memory. */
+INI_API int ini_parse_string(const char* string, ini_handler handler, void* user);
+
+/* Nonzero to allow multi-line value parsing, in the style of Python's
+   configparser. If allowed, ini_parse() will call the handler with the same
+   name for each subsequent line parsed. */
+#ifndef INI_ALLOW_MULTILINE
+#define INI_ALLOW_MULTILINE 1
+#endif
+
+/* Nonzero to allow a UTF-8 BOM sequence (0xEF 0xBB 0xBF) at the start of
+   the file. See https://github.com/benhoyt/inih/issues/21 */
+#ifndef INI_ALLOW_BOM
+#define INI_ALLOW_BOM 1
+#endif
+
+/* Chars that begin a start-of-line comment. Per Python configparser, allow
+   both ; and # comments at the start of a line by default. */
+#ifndef INI_START_COMMENT_PREFIXES
+#define INI_START_COMMENT_PREFIXES ";#"
+#endif
+
+/* Nonzero to allow inline comments (with valid inline comment characters
+   specified by INI_INLINE_COMMENT_PREFIXES). Set to 0 to turn off and match
+   Python 3.2+ configparser behaviour. */
+#ifndef INI_ALLOW_INLINE_COMMENTS
+#define INI_ALLOW_INLINE_COMMENTS 1
+#endif
+#ifndef INI_INLINE_COMMENT_PREFIXES
+#define INI_INLINE_COMMENT_PREFIXES ";"
+#endif
+
+/* Nonzero to use stack for line buffer, zero to use heap (malloc/free). */
+#ifndef INI_USE_STACK
+#define INI_USE_STACK 1
+#endif
+
+/* Maximum line length for any line in INI file (stack or heap). Note that
+   this must be 3 more than the longest line (due to '\r', '\n', and '\0'). */
+#ifndef INI_MAX_LINE
+#define INI_MAX_LINE 200
+#endif
+
+/* Nonzero to allow heap line buffer to grow via realloc(), zero for a
+   fixed-size buffer of INI_MAX_LINE bytes. Only applies if INI_USE_STACK is
+   zero. */
+#ifndef INI_ALLOW_REALLOC
+#define INI_ALLOW_REALLOC 0
+#endif
+
+/* Initial size in bytes for heap line buffer. Only applies if INI_USE_STACK
+   is zero. */
+#ifndef INI_INITIAL_ALLOC
+#define INI_INITIAL_ALLOC 200
+#endif
+
+/* Stop parsing on first error (default is to keep parsing). */
+#ifndef INI_STOP_ON_FIRST_ERROR
+#define INI_STOP_ON_FIRST_ERROR 0
+#endif
+
+/* Nonzero to call the handler at the start of each new section (with
+   name and value NULL). Default is to only call the handler on
+   each name=value pair. */
+#ifndef INI_CALL_HANDLER_ON_NEW_SECTION
+#define INI_CALL_HANDLER_ON_NEW_SECTION 0
+#endif
+
+/* Nonzero to allow a name without a value (no '=' or ':' on the line) and
+   call the handler with value NULL in this case. Default is to treat
+   no-value lines as an error. */
+#ifndef INI_ALLOW_NO_VALUE
+#define INI_ALLOW_NO_VALUE 0
+#endif
+
+/* Nonzero to use custom ini_malloc, ini_free, and ini_realloc memory
+   allocation functions (INI_USE_STACK must also be 0). These functions must
+   have the same signatures as malloc/free/realloc and behave in a similar
+   way. ini_realloc is only needed if INI_ALLOW_REALLOC is set. */
+#ifndef INI_CUSTOM_ALLOCATOR
+#define INI_CUSTOM_ALLOCATOR 0
+#endif
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* INI_H */

--- a/include/rocci.h
+++ b/include/rocci.h
@@ -17,8 +17,8 @@
 #endif
 #include <time.h>          /* For time(), in seconds */
 
-#include <rocci_defines.h>
-//#include <libpressio.h>
+#include <rocci_ByteToolkit.h>
+#include "libpressio.h"
 
 #ifdef _WIN32
 #define PATH_SEPARATOR ';'

--- a/include/rocci.h
+++ b/include/rocci.h
@@ -18,7 +18,9 @@
 #include <time.h>          /* For time(), in seconds */
 
 #include <rocci_ByteToolkit.h>
-#include "libpressio.h"
+#include <rocci_defines.h>
+#include <inih/ini.h>
+#include <libpressio.h>
 
 #ifdef _WIN32
 #define PATH_SEPARATOR ';'

--- a/include/rocci_ByteToolkit.h
+++ b/include/rocci_ByteToolkit.h
@@ -16,8 +16,52 @@ extern "C" {
 
 #include <stdio.h>
 #include <stdint.h>
+#include <string.h>
+#include "rocci_defines.h"
 
 //ByteToolkit.c
+
+int sysEndianType;
+int dataEndianType;
+
+typedef union lint16 {
+    unsigned short usvalue;
+    short svalue;
+    unsigned char byte[2];
+} lint16;
+
+typedef union lint32 {
+    int ivalue;
+    unsigned int uivalue;
+    unsigned char byte[4];
+} lint32;
+
+typedef union lint64 {
+    int64_t lvalue;
+    uint64_t ulvalue;
+    unsigned char byte[8];
+} lint64;
+
+typedef union ldouble {
+    double value;
+    uint64_t lvalue;
+    unsigned char byte[8];
+} ldouble;
+
+typedef union lfloat {
+    float value;
+    unsigned int ivalue;
+    unsigned char byte[4];
+    uint16_t int16[2];
+} lfloat;
+
+void detectSysEndianType();
+
+void symTransform_4bytes(unsigned char data[4]);
+void symTransform_8bytes(unsigned char data[8]);
+
+void setSysEndianType(int endianType);
+void setDataEndianType(int endianType);
 
 extern unsigned short bytesToUInt16_bigEndian(unsigned char* bytes);
 extern unsigned int bytesToUInt32_bigEndian(unsigned char* bytes);

--- a/include/rocci_FileUtil.h
+++ b/include/rocci_FileUtil.h
@@ -1,0 +1,11 @@
+#ifndef _ROCCI_FILE_UTIL
+#define _ROCCI_FILE_UTIL
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <assert.h>
+
+void readfile(const char *file, const size_t num, size_t elem_size, void *data);
+
+#endif

--- a/include/rocci_utils.h
+++ b/include/rocci_utils.h
@@ -1,0 +1,12 @@
+#include <stdlib.h>
+#include <rocci.h>
+
+size_t computeNbEle(size_t r5, size_t r4, size_t r3, size_t r2, size_t r1);
+
+enum pressio_dtype rocci_dtype_to_pressio_dtype(int dataType);
+
+struct pressio_compressor* get_compressor(ROCCI_Setting rocci_config, struct pressio* library);
+
+struct pressio_options* get_compressor_options(ROCCI_Setting rocci_config);
+
+struct pressio_data* create_pressio_data(int dataType, void* data, size_t r5, size_t r4, size_t r3, size_t r2, size_t r1);

--- a/src/H5Z_ROCCI.c
+++ b/src/H5Z_ROCCI.c
@@ -115,7 +115,7 @@ void ROCCI_cdArrayToMetaData(size_t cd_nelmts, const unsigned int cd_values[], i
 
 void H5Z_ROCCI_Init(char* cfgFile)
 {
-
+	ROCCI_Init(cfgFile);
 }
 
 size_t computeDataLength(size_t r5, size_t r4, size_t r3, size_t r2, size_t r1)
@@ -551,13 +551,13 @@ static herr_t H5Z_rocci_set_local(hid_t dcpl_id, hid_t type_id, hid_t chunk_spac
 
 	if(mem_cd_nelmts==0) //this means that the error information is missing from the cd_values
 	{
-		printf("ERR INFO NOT FOUND IN CDVALS\n");
+		// printf("ERR INFO NOT FOUND IN CDVALS\n");
 		H5Z_ROCCI_Init(cfgFile);
 	}
 	else //this means that the error information is included in the cd_values
 	{
 		ROCCI_Init(NULL);
-		printf("ERR INFO FOUND IN CDVALS\n");
+		// printf("ERR INFO FOUND IN CDVALS\n");
 		
 	}
 
@@ -630,6 +630,7 @@ static herr_t H5Z_rocci_set_local(hid_t dcpl_id, hid_t type_id, hid_t chunk_spac
 	}
 	
 	unsigned int* cd_values = NULL;
+	// printf("MEM %i\n", mem_cd_nelmts);
 	if(mem_cd_nelmts!=0 && mem_cd_nelmts!=11)
 	{
 		H5Epush(H5E_DEFAULT,__FILE__, "H5Z_rocci_set_local", __LINE__, H5E_ERR_CLS, H5E_ARGS, H5E_BADVALUE, "Wrong number of cd_values: The new version has 9 integer elements in cd_values. Please check 'test/print_h5repack_args' to get the correct cd_values.");

--- a/src/H5Z_ROCCI.c
+++ b/src/H5Z_ROCCI.c
@@ -556,10 +556,11 @@ static herr_t H5Z_rocci_set_local(hid_t dcpl_id, hid_t type_id, hid_t chunk_spac
 	}
 	else //this means that the error information is included in the cd_values
 	{
-		ROCCI_Init(NULL);
+		H5Z_ROCCI_Init(NULL);
 		// printf("ERR INFO FOUND IN CDVALS\n");
-		
 	}
+
+	init_rocci_flag = 1;
 
 	herr_t ret = H5Zregister(H5Z_ROCCI); 
 	if(ret < 0)
@@ -689,6 +690,11 @@ static size_t H5Z_filter_rocci(unsigned int flags, size_t cd_nelmts, const unsig
 {
 	//printf("start in H5Z_filter_rocci, cd_nelmts=%d\n", cd_nelmts);
 	//H5Z_ROCCI_Init_Default();
+
+	if(!init_rocci_flag) {
+		H5Z_ROCCI_Init(cfgFile);
+		init_rocci_flag = 1;
+	}
 	
 	size_t r1 = 0, r2 = 0, r3 = 0, r4 = 0, r5 = 0;
 	int dimSize = 0, dataType = 0;

--- a/src/inih/ini.c
+++ b/src/inih/ini.c
@@ -1,0 +1,304 @@
+/* inih -- simple .INI file parser
+
+SPDX-License-Identifier: BSD-3-Clause
+
+Copyright (C) 2009-2020, Ben Hoyt
+
+inih is released under the New BSD license (see LICENSE.txt). Go to the project
+home page for more info:
+
+https://github.com/benhoyt/inih
+
+*/
+
+#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
+#include <stdio.h>
+#include <ctype.h>
+#include <string.h>
+
+#include <inih/ini.h>
+
+#if !INI_USE_STACK
+#if INI_CUSTOM_ALLOCATOR
+#include <stddef.h>
+void* ini_malloc(size_t size);
+void ini_free(void* ptr);
+void* ini_realloc(void* ptr, size_t size);
+#else
+#include <stdlib.h>
+#define ini_malloc malloc
+#define ini_free free
+#define ini_realloc realloc
+#endif
+#endif
+
+#define MAX_SECTION 50
+#define MAX_NAME 50
+
+/* Used by ini_parse_string() to keep track of string parsing state. */
+typedef struct {
+    const char* ptr;
+    size_t num_left;
+} ini_parse_string_ctx;
+
+/* Strip whitespace chars off end of given string, in place. Return s. */
+static char* rstrip(char* s)
+{
+    char* p = s + strlen(s);
+    while (p > s && isspace((unsigned char)(*--p)))
+        *p = '\0';
+    return s;
+}
+
+/* Return pointer to first non-whitespace char in given string. */
+static char* lskip(const char* s)
+{
+    while (*s && isspace((unsigned char)(*s)))
+        s++;
+    return (char*)s;
+}
+
+/* Return pointer to first char (of chars) or inline comment in given string,
+   or pointer to NUL at end of string if neither found. Inline comment must
+   be prefixed by a whitespace character to register as a comment. */
+static char* find_chars_or_comment(const char* s, const char* chars)
+{
+#if INI_ALLOW_INLINE_COMMENTS
+    int was_space = 0;
+    while (*s && (!chars || !strchr(chars, *s)) &&
+           !(was_space && strchr(INI_INLINE_COMMENT_PREFIXES, *s))) {
+        was_space = isspace((unsigned char)(*s));
+        s++;
+    }
+#else
+    while (*s && (!chars || !strchr(chars, *s))) {
+        s++;
+    }
+#endif
+    return (char*)s;
+}
+
+/* Similar to strncpy, but ensures dest (size bytes) is
+   NUL-terminated, and doesn't pad with NULs. */
+static char* strncpy0(char* dest, const char* src, size_t size)
+{
+    /* Could use strncpy internally, but it causes gcc warnings (see issue #91) */
+    size_t i;
+    for (i = 0; i < size - 1 && src[i]; i++)
+        dest[i] = src[i];
+    dest[i] = '\0';
+    return dest;
+}
+
+/* See documentation in header file. */
+int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
+                     void* user)
+{
+    /* Uses a fair bit of stack (use heap instead if you need to) */
+#if INI_USE_STACK
+    char line[INI_MAX_LINE];
+    size_t max_line = INI_MAX_LINE;
+#else
+    char* line;
+    size_t max_line = INI_INITIAL_ALLOC;
+#endif
+#if INI_ALLOW_REALLOC && !INI_USE_STACK
+    char* new_line;
+    size_t offset;
+#endif
+    char section[MAX_SECTION] = "";
+    char prev_name[MAX_NAME] = "";
+
+    char* start;
+    char* end;
+    char* name;
+    char* value;
+    int lineno = 0;
+    int error = 0;
+
+#if !INI_USE_STACK
+    line = (char*)ini_malloc(INI_INITIAL_ALLOC);
+    if (!line) {
+        return -2;
+    }
+#endif
+
+#if INI_HANDLER_LINENO
+#define HANDLER(u, s, n, v) handler(u, s, n, v, lineno)
+#else
+#define HANDLER(u, s, n, v) handler(u, s, n, v)
+#endif
+
+    /* Scan through stream line by line */
+    while (reader(line, (int)max_line, stream) != NULL) {
+#if INI_ALLOW_REALLOC && !INI_USE_STACK
+        offset = strlen(line);
+        while (offset == max_line - 1 && line[offset - 1] != '\n') {
+            max_line *= 2;
+            if (max_line > INI_MAX_LINE)
+                max_line = INI_MAX_LINE;
+            new_line = ini_realloc(line, max_line);
+            if (!new_line) {
+                ini_free(line);
+                return -2;
+            }
+            line = new_line;
+            if (reader(line + offset, (int)(max_line - offset), stream) == NULL)
+                break;
+            if (max_line >= INI_MAX_LINE)
+                break;
+            offset += strlen(line + offset);
+        }
+#endif
+
+        lineno++;
+
+        start = line;
+#if INI_ALLOW_BOM
+        if (lineno == 1 && (unsigned char)start[0] == 0xEF &&
+                           (unsigned char)start[1] == 0xBB &&
+                           (unsigned char)start[2] == 0xBF) {
+            start += 3;
+        }
+#endif
+        start = lskip(rstrip(start));
+
+        if (strchr(INI_START_COMMENT_PREFIXES, *start)) {
+            /* Start-of-line comment */
+        }
+#if INI_ALLOW_MULTILINE
+        else if (*prev_name && *start && start > line) {
+#if INI_ALLOW_INLINE_COMMENTS
+            end = find_chars_or_comment(start, NULL);
+            if (*end)
+                *end = '\0';
+            rstrip(start);
+#endif
+            /* Non-blank line with leading whitespace, treat as continuation
+               of previous name's value (as per Python configparser). */
+            if (!HANDLER(user, section, prev_name, start) && !error)
+                error = lineno;
+        }
+#endif
+        else if (*start == '[') {
+            /* A "[section]" line */
+            end = find_chars_or_comment(start + 1, "]");
+            if (*end == ']') {
+                *end = '\0';
+                strncpy0(section, start + 1, sizeof(section));
+                *prev_name = '\0';
+#if INI_CALL_HANDLER_ON_NEW_SECTION
+                if (!HANDLER(user, section, NULL, NULL) && !error)
+                    error = lineno;
+#endif
+            }
+            else if (!error) {
+                /* No ']' found on section line */
+                error = lineno;
+            }
+        }
+        else if (*start) {
+            /* Not a comment, must be a name[=:]value pair */
+            end = find_chars_or_comment(start, "=:");
+            if (*end == '=' || *end == ':') {
+                *end = '\0';
+                name = rstrip(start);
+                value = end + 1;
+#if INI_ALLOW_INLINE_COMMENTS
+                end = find_chars_or_comment(value, NULL);
+                if (*end)
+                    *end = '\0';
+#endif
+                value = lskip(value);
+                rstrip(value);
+
+                /* Valid name[=:]value pair found, call handler */
+                strncpy0(prev_name, name, sizeof(prev_name));
+                if (!HANDLER(user, section, name, value) && !error)
+                    error = lineno;
+            }
+            else if (!error) {
+                /* No '=' or ':' found on name[=:]value line */
+#if INI_ALLOW_NO_VALUE
+                *end = '\0';
+                name = rstrip(start);
+                if (!HANDLER(user, section, name, NULL) && !error)
+                    error = lineno;
+#else
+                error = lineno;
+#endif
+            }
+        }
+
+#if INI_STOP_ON_FIRST_ERROR
+        if (error)
+            break;
+#endif
+    }
+
+#if !INI_USE_STACK
+    ini_free(line);
+#endif
+
+    return error;
+}
+
+/* See documentation in header file. */
+int ini_parse_file(FILE* file, ini_handler handler, void* user)
+{
+    return ini_parse_stream((ini_reader)fgets, file, handler, user);
+}
+
+/* See documentation in header file. */
+int ini_parse(const char* filename, ini_handler handler, void* user)
+{
+    FILE* file;
+    int error;
+
+    file = fopen(filename, "r");
+    if (!file)
+        return -1;
+    error = ini_parse_file(file, handler, user);
+    fclose(file);
+    return error;
+}
+
+/* An ini_reader function to read the next line from a string buffer. This
+   is the fgets() equivalent used by ini_parse_string(). */
+static char* ini_reader_string(char* str, int num, void* stream) {
+    ini_parse_string_ctx* ctx = (ini_parse_string_ctx*)stream;
+    const char* ctx_ptr = ctx->ptr;
+    size_t ctx_num_left = ctx->num_left;
+    char* strp = str;
+    char c;
+
+    if (ctx_num_left == 0 || num < 2)
+        return NULL;
+
+    while (num > 1 && ctx_num_left != 0) {
+        c = *ctx_ptr++;
+        ctx_num_left--;
+        *strp++ = c;
+        if (c == '\n')
+            break;
+        num--;
+    }
+
+    *strp = '\0';
+    ctx->ptr = ctx_ptr;
+    ctx->num_left = ctx_num_left;
+    return str;
+}
+
+/* See documentation in header file. */
+int ini_parse_string(const char* string, ini_handler handler, void* user) {
+    ini_parse_string_ctx ctx;
+
+    ctx.ptr = string;
+    ctx.num_left = strlen(string);
+    return ini_parse_stream((ini_reader)ini_reader_string, &ctx, handler,
+                            user);
+}

--- a/src/rocci.c
+++ b/src/rocci.c
@@ -12,12 +12,83 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include "rocci.h"
+#include <rocci.h>
+#include <rocci_utils.h>
 
 int versionNumber[4] = {ROCCI_VER_MAJOR,ROCCI_VER_MINOR,ROCCI_VER_BUILD,ROCCI_VER_REVISION};
 
+const char* COMPRESSOR_STR[] = {"SZ2", "SZ3", "QOZ", "ZFP", "DR", "BG", "SZX"};
+int COMPRESSOR_OPTIONS[] = {ROCCI_SZ2, ROCCI_SZ3, ROCCI_QOZ, ROCCI_ZFP, ROCCI_DR, ROCCI_BG, ROCCI_SZX};
+
+const char* CMP_MODE_STR[] = {"ABS", "REL", "VR_REL", "ABS_AND_REL", "ABS_OR_REL", "PSNR", "NORM", "FIX_RATE"};
+int CMP_MODE_OPTIONS[] = {ABS, REL, VR_REL, ABS_AND_REL, ABS_OR_REL, PSNR, NORM, FIX_RATE};
+
+ROCCI_Setting rocci_config;
+
+static int rocci_ini_config_handler(void* user, const char* section, const char* name,
+                   const char* value)
+{
+    ROCCI_Setting* config = (ROCCI_Setting*)user;
+
+    #define MATCH(s, n) strcmp(section, s) == 0 && strcmp(name, n) == 0
+
+	if(MATCH("GlobalSettings", "CompressorID")){
+		int nCompressors = sizeof(COMPRESSOR_STR) / sizeof(char*);
+		for(int i = 0; i < nCompressors; i++){
+			if(strcmp(value, COMPRESSOR_STR[i]) == 0){
+				config->compressorID = COMPRESSOR_OPTIONS[i];
+			}
+		}
+	}
+	else if(MATCH("GlobalSettings", "CompressionMode")){
+		int nModes = sizeof(CMP_MODE_STR) / sizeof(char*);
+		for(int i = 0; i < nModes; i++){
+			if(strcmp(value, CMP_MODE_STR[i]) == 0){
+				config->compressionMode = CMP_MODE_OPTIONS[i];
+			}
+		}
+	}
+	else if(MATCH("GlobalSettings", "AbsErrorBound")) {
+		config->absErrorBound = atof(value);
+	}
+	else if(MATCH("GlobalSettings", "RelErrorBound")) {
+		config->relErrorBound = atof(value);
+	}
+	else if(MATCH("GlobalSettings", "Precision")) {
+		config->precision = atoi(value);
+	}
+	else if(MATCH("GlobalSettings", "FixedCompressionRate")) {
+		config->rate = atof(value);
+	} 
+	else {
+		printf("Unknown section or name: %s/%s\n", section, name);
+        return 0;
+    }
+    return 1;
+}
+
 void ROCCI_Init(char* cfgFile)
-{}
+{
+	if(cfgFile == NULL){
+		rocci_config.compressorID = ROCCI_SZ3;
+		rocci_config.compressionMode = ABS;
+		rocci_config.absErrorBound = 0.01;
+		rocci_config.relErrorBound = 0;
+		rocci_config.precision = 0;
+		rocci_config.rate = 0;
+		printf("Warning: No config file found, using defaults\n");
+		return;
+	}
+
+	printf("Reading %s...\n", cfgFile);
+	if (ini_parse(cfgFile, rocci_ini_config_handler, &rocci_config) < 0) {
+        printf("Unable to load config file: %s\n", cfgFile);
+        exit(0);
+    }
+
+	printf("Succesfully loaded config: %s\n", cfgFile);
+	// printf("CONFIG: %i %i %f %f %i %f\n", rocci_config.compressorID, rocci_config.compressionMode, rocci_config.absErrorBound, rocci_config.relErrorBound, rocci_config.precision, rocci_config.rate);
+}
 
 int rocciFidelity_multiFields(float** oriData, float** decData, float** fidelity, size_t r5, size_t r4, size_t r3, size_t r2, size_t r1)
 {
@@ -36,17 +107,75 @@ int roccifastSearchBestSetting (int metric, int compressorID, ROCCI_Target input
 
 unsigned char* ROCCI_compress_args(int dataType, void* data, size_t* outSize, int error_mode, double abs_error, double rel_error, double pw_rel_error, double psnr, double ratio, size_t r5, size_t r4, size_t r3, size_t r2, size_t r1)
 {
-	return NULL;
+	struct pressio* library = pressio_instance();
+	struct pressio_compressor* comp = get_compressor(rocci_config, library);
+	struct pressio_data* input_data = create_pressio_data(dataType, data, r5, r4, r3, r2, r1);
+    struct pressio_data* compressed = pressio_data_new_empty(pressio_byte_dtype, 0, NULL);
+	struct pressio_options* comp_options = get_compressor_options(rocci_config);
+	if(pressio_compressor_set_options(comp, comp_options)) {
+		fprintf(stderr, "%s\n", pressio_compressor_error_msg(comp));
+		return NULL;
+	}
+  	pressio_options_free(comp_options);
+
+	if(pressio_compressor_compress(comp, input_data, compressed)) {
+      fprintf(stderr, "%s\n", pressio_compressor_error_msg(comp));
+		return NULL;
+    }
+
+	void* output_data = pressio_data_ptr(compressed, outSize);
+	pressio_compressor_release(comp);
+	pressio_release(library);
+
+	return (unsigned char*)output_data;
 }
 
 unsigned char* ROCCI_compress(int dataType, void* data, size_t* outSize, size_t r5, size_t r4, size_t r3, size_t r2, size_t r1)
 {
-	return NULL;
+	struct pressio* library = pressio_instance();
+	struct pressio_compressor* comp = get_compressor(rocci_config, library);
+	struct pressio_data* input_data = create_pressio_data(dataType, data, r5, r4, r3, r2, r1);
+    struct pressio_data* compressed = pressio_data_new_empty(pressio_byte_dtype, 0, NULL);
+	struct pressio_options* comp_options = get_compressor_options(rocci_config);
+	if(pressio_compressor_set_options(comp, comp_options)) {
+		fprintf(stderr, "%s\n", pressio_compressor_error_msg(comp));
+		return NULL;
+	}
+  	pressio_options_free(comp_options);
+
+	if(pressio_compressor_compress(comp, input_data, compressed)) {
+      fprintf(stderr, "%s\n", pressio_compressor_error_msg(comp));
+		return NULL;
+    }
+
+	void* output_data = pressio_data_ptr(compressed, outSize);
+	pressio_compressor_release(comp);
+	pressio_release(library);
+
+	return (unsigned char*)output_data;
 }
 
 void* ROCCI_decompress(int dataType, char *buf, size_t nbytes, size_t r5, size_t r4, size_t r3, size_t r2, size_t r1)
 {
-	return NULL;
+	size_t nbEle = computeNbEle(r5, r4, r3, r2, r1);
+
+	struct pressio* library = pressio_instance();
+  	struct pressio_compressor* comp = get_compressor(rocci_config, library);
+	size_t dim[1] = {nbytes};
+    struct pressio_data* compressed_data = pressio_data_new_move(pressio_byte_dtype, buf, 1, dim, NULL, NULL);
+	struct pressio_data* output = create_pressio_data(dataType, NULL, r5, r4, r3, r2, r1);
+
+	if(pressio_compressor_decompress(comp, compressed_data, output)) {
+      fprintf(stderr, "%s\n", pressio_compressor_error_msg(comp));
+	  exit(0);
+    }
+
+	size_t outSize = 0;
+	float* output_data = pressio_data_ptr(output, &outSize);
+	pressio_compressor_release(comp);
+	pressio_release(library);
+
+	return output_data;
 }
 
 

--- a/src/rocci_ByteToolkit.c
+++ b/src/rocci_ByteToolkit.c
@@ -8,6 +8,56 @@
  */
  
 #include <stdlib.h>
+#include "rocci_ByteToolkit.h"
+
+void detectSysEndianType()
+{
+    //get sys endian type
+    int x_temp = 1;
+    char *y_temp = (char*)&x_temp;
+
+    if(*y_temp==1)
+        sysEndianType = LITTLE_ENDIAN_SYSTEM;
+    else //=0
+        sysEndianType = BIG_ENDIAN_SYSTEM;
+}
+
+void setSysEndianType(int endianType){
+	sysEndianType = endianType;
+}
+
+void setDataEndianType(int endianType){
+	dataEndianType = endianType;
+}
+
+void symTransform_4bytes(unsigned char data[4]) {
+    unsigned char tmp = data[0];
+    data[0] = data[3];
+    data[3] = tmp;
+
+    tmp = data[1];
+    data[1] = data[2];
+    data[2] = tmp;
+}
+
+void symTransform_8bytes(unsigned char data[8])
+{
+	unsigned char tmp = data[0];
+	data[0] = data[7];
+	data[7] = tmp;
+
+	tmp = data[1];
+	data[1] = data[6];
+	data[6] = tmp;
+	
+	tmp = data[2];
+	data[2] = data[5];
+	data[5] = tmp;
+	
+	tmp = data[3];
+	data[3] = data[4];
+	data[4] = tmp;
+}
 
 inline unsigned short bytesToUInt16_bigEndian(unsigned char* bytes)
 {

--- a/src/rocci_FileUtil.c
+++ b/src/rocci_FileUtil.c
@@ -1,0 +1,20 @@
+//
+// Created by Kai Zhao on 12/9/19.
+//
+
+#include "rocci_FileUtil.h"
+
+void readfile(const char *file, const size_t num, size_t elem_size, void *data) {
+    FILE *fin = fopen(file, "rb");
+    if (!fin) {
+        printf("Error, Couldn't find the file: %s\n", file);
+        exit(0);
+    }
+    fseek(fin, 0, SEEK_END);
+    const size_t num_elements = ftell(fin) / elem_size;
+    assert(num_elements == num && "File size is not equal to the input setting");
+    fseek(fin, 0, SEEK_SET);
+    fread(data, elem_size, num_elements, fin);
+    fclose(fin);
+}
+

--- a/src/rocci_utils.c
+++ b/src/rocci_utils.c
@@ -1,0 +1,149 @@
+#include <rocci_utils.h>
+
+size_t computeNbEle(size_t r5, size_t r4, size_t r3, size_t r2, size_t r1){
+	size_t n = 0;
+    if (r2 == 0) {
+        n = r1;
+    } else if (r3 == 0) {
+        n = r1 * r2;
+    } else if (r4 == 0) {
+        n = r1 * r2 * r3;
+    } else if (r5 == 0) {
+        n = r1 * r2 * r3 * r4;
+    } else {
+        n = r1 * r2 * r3 * r4 * r5;
+    }
+
+	return n;
+}
+
+enum pressio_dtype rocci_dtype_to_pressio_dtype(int dataType){
+	switch(dataType){
+		case ROCCI_FLOAT:
+			return pressio_float_dtype;
+		case ROCCI_DOUBLE:
+			return pressio_double_dtype;
+		case ROCCI_UINT8:
+			return pressio_uint8_dtype;
+		case ROCCI_INT8:
+			return pressio_int8_dtype;
+		case ROCCI_UINT16:
+			return pressio_uint16_dtype;
+		case ROCCI_INT16:
+			return pressio_int16_dtype;
+		case ROCCI_UINT32:
+			return pressio_uint32_dtype;
+		case ROCCI_INT32:
+			return pressio_int32_dtype;
+		case ROCCI_UINT64:
+			return pressio_uint64_dtype;
+		case ROCCI_INT64:
+			return pressio_int64_dtype;
+		default:
+			printf("Unrecognized data type\n");
+			exit(0);
+	}
+}
+
+struct pressio_compressor* get_compressor(ROCCI_Setting rocci_config, struct pressio* library){
+	char* compressor_id;
+	switch(rocci_config.compressorID){
+		case ROCCI_SZ2:
+			compressor_id = "sz";
+			break;
+		case ROCCI_SZ3:
+			compressor_id = "sz3";
+			break;
+		case ROCCI_QOZ:
+			compressor_id = "qoz";
+			break;
+		case ROCCI_ZFP:
+			compressor_id = "zfp";
+			break;
+		case ROCCI_DR:
+			compressor_id = "dr";
+			break;
+		case ROCCI_BG:
+			compressor_id = "bg";
+			break;
+		case ROCCI_SZX:
+			compressor_id = "szx";
+			break;
+		default:
+			printf("Undefined compressor ID in ROCCI Configuration\n");
+			exit(0);
+	}
+
+	printf("compressor: %s\n", compressor_id);
+	struct pressio_compressor* comp = pressio_get_compressor(library, compressor_id);
+	return comp;
+}
+
+struct pressio_options* get_compressor_options(ROCCI_Setting rocci_config)
+{
+	struct pressio_options* comp_options = pressio_options_new();
+	switch(rocci_config.compressionMode)
+	{
+		case ABS:
+			pressio_options_set_double(comp_options, "pressio:abs", rocci_config.absErrorBound);
+			break;
+		case REL:
+			pressio_options_set_double(comp_options, "pressio:rel", rocci_config.relErrorBound);
+			break;
+		default:
+			printf("Error: unknown compression mode\n");
+			exit(0);
+	}
+
+	return comp_options;
+}
+
+struct pressio_data* create_pressio_data(int dataType, void* data, size_t r5, size_t r4, size_t r3, size_t r2, size_t r1)
+{
+	size_t nDims;
+	size_t nbEle;
+	size_t dims[5];
+	if(r2 == 0){
+		nDims = 1;
+		nbEle = r1;
+		dims[0] = r1;
+	} else if (r3 == 0){
+		nDims = 2;
+		nbEle = r1*r2;
+		dims[0] = r2;
+		dims[1] = r1;
+	} else if (r4 == 0){
+		nDims = 3;
+		nbEle = r1*r2*r3;
+		dims[0] = r3;
+		dims[1] = r2;
+		dims[2] = r1;
+	} else if (r5 == 0){
+		nDims = 4;
+		nbEle = r1*r2*r3*r4;
+		dims[0] = r4;
+		dims[1] = r3;
+		dims[2] = r2;
+		dims[3] = r1;
+	} else {
+		nDims = 5;
+		nbEle = r1*r2*r3*r4*r5;
+		dims[0] = r5;
+		dims[1] = r4;
+		dims[2] = r3;
+		dims[3] = r2;
+		dims[4] = r1;
+	}
+
+	enum pressio_dtype data_type = rocci_dtype_to_pressio_dtype(dataType);
+	struct pressio_data* data_buffer;
+	if(data == NULL){
+		float* x = malloc(sizeof(float)*nbEle);
+		data_buffer = pressio_data_new_move(data_type, x, nDims, dims, NULL, NULL);
+	}
+	else {
+		data_buffer = pressio_data_new_move(data_type, data, nDims, dims, pressio_data_libc_free_fn, NULL);
+	}
+	
+	return data_buffer;
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,9 +1,10 @@
 function(build_hdf5_test)
   get_filename_component(test_name ${ARGV0} NAME_WE)
   add_executable(${test_name} ${ARGV})
-  target_link_libraries(${test_name} PUBLIC SZ hdf5sz)
+  target_link_libraries(${test_name} PUBLIC ROCCI hdf5rocci)
 endfunction(build_hdf5_test)
 
-build_hdf5_test(szToHDF5.c) 
-build_hdf5_test(dszFromHDF5.c)
+build_hdf5_test(rocciToHDF5.c) 
+build_hdf5_test(drocciFromHDF5.c)
 build_hdf5_test(convertBinToHDF5.c)
+build_hdf5_test(print_h5repack_args.c)

--- a/test/drocciFromHDF5.c
+++ b/test/drocciFromHDF5.c
@@ -67,7 +67,6 @@ int main(int argc, char * argv[])
 		printf("Error: H5Dget_type(dset) < 0\n");
 
 	/*Read the data*/
-	H5Z_ROCCI_Init(cfgFile);
 	printf("....Reading ROCCI compressed data .....................\n");
 
 	if((type_class = H5Tget_class(dtype)) < 0)

--- a/test/drocciFromHDF5.c
+++ b/test/drocciFromHDF5.c
@@ -1,9 +1,9 @@
 /**
  *  @file drocciFromHDF5.c
  *  @author Sheng Di
- *  @date July, 2017
+ *  @date Sept, 2023
  *  @brief This is an example of using decompression interface (HDF5)
- *  (C) 2017 by Mathematics and Computer Science (MCS), Argonne National Laboratory.
+ *  (C) 2023 by Mathematics and Computer Science (MCS), Argonne National Laboratory.
  *      See COPYRIGHT in top-level directory.
  */
 
@@ -38,15 +38,15 @@ int main(int argc, char * argv[])
 	if(argc < 2)
 	{
 		printf("Test case: drocciFromHDF5 [hdf5FilePath]\n");
-		printf("Example 1: drocciFromHDF5 testdata/x86/testfloat_8_8_128.dat.sz.hdf5\n");
-		printf("Example 2: drocciFromHDF5 testdata/x86/testint32_8x8x8.dat.sz.hdf5\n");
+		printf("Example 1: drocciFromHDF5 testdata/x86/testfloat_8_8_128.dat.rocci.hdf5\n");
+		printf("Example 2: drocciFromHDF5 testdata/x86/testint32_8x8x8.dat.rocci.hdf5\n");
 		exit(0);
 	}
 
 	sprintf(hdf5FilePath, "%s", argv[1]);
 	sprintf(outputFilePath, "%s.out.h5", hdf5FilePath);
 
-	/*Open the hdf5 file with SZ-compressed data*/
+	/*Open the hdf5 file with ROCCI-compressed data*/
     file = H5Fopen(hdf5FilePath, H5F_ACC_RDONLY, H5P_DEFAULT);
     dset = H5Dopen(file, DATASET, H5P_DEFAULT);
     
@@ -66,7 +66,8 @@ int main(int argc, char * argv[])
 	if((dtype = H5Dget_type(dset)) < 0)
 		printf("Error: H5Dget_type(dset) < 0\n");
 
-	/*Read the data using the default properties.*/
+	/*Read the data*/
+	H5Z_ROCCI_Init(cfgFile);
 	printf("....Reading ROCCI compressed data .....................\n");
 
 	if((type_class = H5Tget_class(dtype)) < 0)

--- a/test/drocciFromHDF5.c
+++ b/test/drocciFromHDF5.c
@@ -1,5 +1,5 @@
 /**
- *  @file dszFromHDF5.c
+ *  @file drocciFromHDF5.c
  *  @author Sheng Di
  *  @date July, 2017
  *  @brief This is an example of using decompression interface (HDF5)
@@ -12,8 +12,7 @@
 #include <stdlib.h>
 #include <dlfcn.h>
 #include "hdf5.h"
-#include "sz.h"
-#include "H5Z_SZ.h"
+#include "H5Z_ROCCI.h"
 
 #define DATASET "testdata_compressed"
 #define MAX_CHUNK_SIZE 4294967295 //2^32-1
@@ -38,9 +37,9 @@ int main(int argc, char * argv[])
 
 	if(argc < 2)
 	{
-		printf("Test case: dszFromHDF5 [hdf5FilePath]\n");
-		printf("Example 1: dszFromHDF5 testdata/x86/testfloat_8_8_128.dat.sz.hdf5\n");
-		printf("Example 2: dszFromHDF5 testdata/x86/testint32_8x8x8.dat.sz.hdf5\n");
+		printf("Test case: drocciFromHDF5 [hdf5FilePath]\n");
+		printf("Example 1: drocciFromHDF5 testdata/x86/testfloat_8_8_128.dat.sz.hdf5\n");
+		printf("Example 2: drocciFromHDF5 testdata/x86/testint32_8x8x8.dat.sz.hdf5\n");
 		exit(0);
 	}
 
@@ -55,11 +54,11 @@ int main(int argc, char * argv[])
     dcpl = H5Dget_create_plist(dset);
 	
     /*Check that filter is not registered with the library yet*/
-	avail = H5Zfilter_avail(H5Z_FILTER_SZ);
+	avail = H5Zfilter_avail(H5Z_FILTER_ROCCI);
 	if(!avail)
-		printf("sz filter is not yet available after the H5Pget_filter call.\n");
+		printf("rocci filter is not yet available after the H5Pget_filter call.\n");
 	else
-		printf("sz filter is available.\n");
+		printf("rocci filter is available.\n");
 	
 	space_id = H5Dget_space(dset);	
 	nbEle = H5Sget_simple_extent_npoints(space_id);
@@ -68,7 +67,7 @@ int main(int argc, char * argv[])
 		printf("Error: H5Dget_type(dset) < 0\n");
 
 	/*Read the data using the default properties.*/
-	printf("....Reading SZ compressed data .....................\n");
+	printf("....Reading ROCCI compressed data .....................\n");
 
 	if((type_class = H5Tget_class(dtype)) < 0)
 	{
@@ -256,7 +255,7 @@ int main(int argc, char * argv[])
 		
 		break;
 	default: 
-		printf("Error: H5Z-SZ supports only float, double or integers.\n");
+		printf("Error: H5Z-ROCCI supports only float, double or integers.\n");
 		exit(0);
 	}
 	

--- a/test/h5repack.sh
+++ b/test/h5repack.sh
@@ -3,7 +3,7 @@
 if [[ $# != 2 ]]
 then
 	echo "Usage: $0 [inputf_hdf5_ile] [output_hdf5_file]"
-	echo "Example: $0 testfloat_8_8_128.h5 testfloat_8_8_128_sz.h5"
+	echo "Example: $0 testfloat_8_8_128.h5 testfloat_8_8_128.rocci.h5"
 	exit
 fi
 

--- a/test/h5repack.sh
+++ b/test/h5repack.sh
@@ -9,4 +9,4 @@ fi
 
 inputFile=$1
 outputFile=$2
-h5repack -f UD=32017,0 -i $inputFile -o $outputFile
+h5repack -f UD=32037,0 -i $inputFile -o $outputFile

--- a/test/print_h5repack_args.c
+++ b/test/print_h5repack_args.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
-#include <sz.h> 
+#include "rocci.h"
 
 void usage()
 {
@@ -17,8 +17,8 @@ void usage()
 	printf("	-P <point-wise relative error bound>: specifying point-wise relative error bound\n");
 	printf("	-S <PSNR>: specifying PSNR\n");
 	printf("* examples: \n");
-	printf("	print_h5repack_args -M ABS -A 1E-3 (output: -f UD=32017,0,9,0,1062232653,3539053052,0,0,0,0,0,0)\n");
-	printf("	print_h5repack_args -M REL -R 1E-4 (output: -f UD=32017,0,9,1,0,0,1058682594,3944497965,0,0,0,0)\n");
+	printf("	print_h5repack_args -M ABS -A 1E-3 (output: -f UD=32037,0,9,0,1062232653,3539053052,0,0,0,0,0,0)\n");
+	printf("	print_h5repack_args -M REL -R 1E-4 (output: -f UD=32037,0,9,1,0,0,1058682594,3944497965,0,0,0,0)\n");
 	exit(0);
 }
 
@@ -135,7 +135,7 @@ int main(int argc, char* argv[])
 		printf("Error: wrong errBoundMode setting.\n");
 		exit(0);
 	}
-	printf("-f UD=32017,0,9");
+	printf("-f UD=32037,0,9");
 
 	for(i=0;i<9;i++)
 		printf(",%u",cd_values[i]);

--- a/test/rocci.config
+++ b/test/rocci.config
@@ -1,0 +1,28 @@
+[GlobalSettings]
+
+#Compressors: SZ2, SZ3, QOZ, ZFP, DR, BG, SZX
+CompressorID = SZ3
+
+
+#CompressionMode: 6 options to control different types of error bounds
+#ABS, REL, VR_REL, ABS_AND_REL, ABS_OR_REL, PSNR, NORM, FIX_RATE
+CompressionMode = ABS
+
+#Absolute Error Bound (NOTE: it's valid when CompressionMode is related to ABS (i.e., absolute error bound))
+#absErrBound is to limit the (de)compression errors to be within an absolute error.
+#For example, absErrBound=0.0001 means the decompressed value must be in [V-0.0001,V+0.0001], where V is the original true value.
+AbsErrorBound = 0.001
+
+#Relative Error Bound Ratio (NOTE: it's valid only when CompressionMode is related to REL (i.e., value_range based relative error bound))
+#relErrBound is to limit the (de)compression errors by considering the global data value range size (i.e., taking into account the range size (max_value - min_value)).
+#For example, suppose relBoundRatio is set to 0.01, and the data set is {100,101,102,103,104,...,110},
+#so the global value range size is 110-100=10, so the error bound will actually be 10*0.01=0.1, from the perspective of "relBoundRatio"
+RelErrorBound = 1e-6
+
+Precision = 2
+
+#expected Compression Ratio (Note: only valid when CompressionMode = FIX_RATE)
+FixedCompressionRate = 0.6
+
+
+

--- a/test/rocciToHDF5.c
+++ b/test/rocciToHDF5.c
@@ -1,0 +1,554 @@
+/**
+ *  @file szToHDF5.c
+ *  @author Sheng Di
+ *  @date July, 2017
+ *  @brief This is an example of using compression interface (HDF5)
+ *  (C) 2017 by Mathematics and Computer Science (MCS), Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <dlfcn.h>
+#include "rocci_FileUtil.h"
+#include "hdf5.h"
+#include "H5Z_ROCCI.h"
+
+#define DATASET "testdata_compressed"
+
+
+// using namespace SZ;
+
+dataEndianType = LITTLE_ENDIAN_DATA;
+
+int main(int argc, char *argv[]) {
+
+    //(void) helper fn to detect system endian type
+    //detectSysEndianType();
+    //by default sysEndianType and dataEndianType are little endian, can set them manually here
+    //dataEndianType = BIG_ENDIAN_DATA;
+
+    size_t r5 = 0, r4 = 0, r3 = 0, r2 = 0, r1 = 0;
+    int cmp_algo, interp_algo; //select compression and interpolation for SZ3
+    char outDir[640], oriFilePath[640], outputFilePath[640];
+    size_t cd_nelmts, nbEle;
+    unsigned int *cd_values = NULL;
+    //unsigned int cd_values[7];
+
+    herr_t status;
+    htri_t avail;
+    unsigned filter_config;
+
+    hid_t sid, idsid, cpid, fid;
+
+    if (argc < 3) {
+        printf("Test case: rocciToHDF5 [dataType] [srcFilePath] [dimension sizes...]\n");
+        printf("Example1 : rocciToHDF5 -f testdata/x86/testfloat_8_8_128.dat 8 8 128\n");
+        printf("Example 2: rocciToHDF5 -i32 testdata/x86/testint32_8x8x8.dat 8 8 8\n");
+        exit(0);
+    }
+
+    //printf("config file = %s\n", argv[2]);
+
+    int dataType = 0;
+    if (strcmp(argv[1], "-f") == 0)
+        dataType = ROCCI_FLOAT;
+    else if (strcmp(argv[1], "-d") == 0)
+        dataType = ROCCI_DOUBLE;
+    else if (strcmp(argv[1], "-i8") == 0)
+        dataType = ROCCI_INT8;
+    else if (strcmp(argv[1], "-u8") == 0)
+        dataType = ROCCI_UINT8;
+    else if (strcmp(argv[1], "-i16") == 0)
+        dataType = ROCCI_INT16;
+    else if (strcmp(argv[1], "-u16") == 0)
+        dataType = ROCCI_UINT16;
+    else if (strcmp(argv[1], "-i32") == 0)
+        dataType = ROCCI_INT32;
+    else if (strcmp(argv[1], "-u32") == 0)
+        dataType = ROCCI_UINT32;
+    else if (strcmp(argv[1], "-i64") == 0)
+        dataType = ROCCI_INT64;
+    else if (strcmp(argv[1], "-u64") == 0)
+        dataType = ROCCI_UINT64;
+    else {
+        printf("Error: unknown data type in sz3ToHDF5.c!\n");
+        exit(0);
+    }
+
+    printf("DTYPE: %i", dataType);
+    snprintf(oriFilePath, 640, "%s", argv[2]);
+    if (argc >= 4) {
+        r1 = atoi(argv[3]); //8
+    }
+    if (argc >= 5) {
+        r2 = atoi(argv[4]); //8
+    }
+    if (argc >= 6) {
+        r3 = atoi(argv[5]); //128
+    }
+    if (argc >= 7) {
+        r4 = atoi(argv[6]);
+    }
+    if (argc >= 8) {
+        r5 = atoi(argv[7]);
+    }
+
+    //read in compression and interp algo
+    //for testing set these here as defaults in config
+    cmp_algo = 1;
+    interp_algo = 1;
+
+    //printf("cfgFile=%s\n", cfgFile);
+    snprintf(outputFilePath, 640, "%s.sz3.h5", oriFilePath);
+
+//	printf("argv[1]=%s, dataType=%d\n", argv[1], dataType);
+    nbEle = computeDataLength(r5, r4, r3, r2, r1);
+
+//	printf("nbEle=%u\n", nbEle);
+
+    //Create cd_values
+    printf("Dimension sizes: n5=%u, n4=%u, n3=%u, n2=%u, n1=%u\n", r5, r4, r3, r2, r1);
+    int mode = 1; //0: ABS, 1: REL, ...
+    ROCCI_errConfigToCdArray(&cd_nelmts, &cd_values, mode, 0.001, 0.001, 0,
+                          0, 60.0); //SZ_FLOAT or SZ_DOUBLE or SZ_INT 100x500x500 : 0, 0, 100, 500, 500, ABS, REL (0.01, 0.01*(max-min), PW_REL (0.01, 5, 6, 7, 8, 9 --> 5*0.01, 6*0.01, ...), PSNR (mean squared error)).
+    //load_conffile_flag = 0;
+    //										 REL
+    //SZ_metaDataErrToCdArray(&cd_nelmts, &cd_values, dataType, r5, r4, r3, r2, r1, 1, 0.01, 0.01, 0, 0); //SZ_FLOAT or SZ_DOUBLE or SZ_INT 100x500x500 : 0, 0, 100, 500, 500, ABS, REL (0.01, 0.01*(max-min), PW_REL (0.01, 5, 6, 7, 8, 9 --> 5*0.01, 6*0.01, ...), PSNR (mean squared error)).
+    /*cd_nelmts = 5;
+    cd_values[0] = 3;
+    cd_values[1] = 0;
+    cd_values[2] = 128;
+    cd_values[3] = 8;
+    cd_values[4] = 8;
+    cd_values[5] = 0;
+    cd_values[6] = 0;*/
+
+    int i = 0;
+	for(i=0;i<cd_nelmts;i++)
+		printf("cd_values[%d]=%u\n", i, cd_values[i]);
+
+    //compute dimension
+    int dim = computeDimension(r5, r4, r3, r2, r1);
+
+    hsize_t dims[5] = {0, 0, 0, 0, 0}, chunk[5] = {0, 0, 0, 0, 0};
+    init_dims_chunk(dim, dims, chunk, nbEle, r5, r4, r3, r2, r1);
+
+    /* create HDF5 file */
+    if (0 > (fid = H5Fcreate(outputFilePath, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT))) {
+        printf("Error in H5Fcreate");
+        exit(0);
+    }
+
+    /*Create dataspace. Setting maximum size */
+    if (0 > (sid = H5Screate_simple(dim, dims, NULL))) {
+        printf("Error in H5Screate_simple");
+        exit(0);
+    }
+
+    /* setup dataset creation properties */
+    if (0 > (cpid = H5Pcreate(H5P_DATASET_CREATE))) {
+        printf("Error in H5Pcreate");
+        exit(0);
+    }
+
+    /* Add the SZ compression filter and set the chunk size */
+    if (0 > H5Pset_filter(cpid, H5Z_FILTER_ROCCI, H5Z_FLAG_MANDATORY, cd_nelmts, cd_values)) {
+        printf("Error in H5Psetfilter");
+        exit(0);
+    }
+    avail = H5Zfilter_avail(H5Z_FILTER_ROCCI);
+    if (avail) {
+        status = H5Zget_filter_info(H5Z_FILTER_ROCCI, &filter_config);
+
+        if (filter_config & H5Z_FILTER_CONFIG_ENCODE_ENABLED)
+            printf("sz filter is available for encoding and decoding.\n");
+    }
+    else{
+        printf("ROCCI filter not available, make sure to set HDF5_PLUGIN_PATH\n");
+        exit(0);
+    }
+    if (0 > H5Pset_chunk(cpid, dim, chunk)) {
+        printf("Error in H5Pcreate");
+        exit(0);
+    }
+
+    //Initialize the configuration for SZ
+    //You can also use the global variable conf_params to set the configuration for sz without cfgFile.
+    //Example of setting an absolute error bound:
+    //			sz_params* params = H5Z_SZ_Init_Default();
+    //			params->errorBoundMode = ABS;
+    //			params->absErrBound = 1E-4;
+
+    //H5Z_SZ_Init(cfgFile);
+
+    printf("....Writing SZ compressed data.............\n");
+
+    if (dataType == ROCCI_FLOAT) {
+        float *data = malloc(sizeof(float)*nbEle);
+        readfile(oriFilePath, nbEle, sizeof(float), data);
+
+        printf("original data = ");
+        for (i = 0; i < 20; i++)
+            printf("%f ", data[i]);
+        printf("....\n");
+
+        if (dataEndianType == LITTLE_ENDIAN_DATA) {
+            if (0 > (idsid = H5Dcreate(fid, DATASET, H5T_IEEE_F32LE, sid, H5P_DEFAULT, cpid, H5P_DEFAULT))) {
+                printf("Error in H5Dcreate");
+                exit(0);
+            }
+            if (0 > H5Dwrite(idsid, H5T_IEEE_F32LE, H5S_ALL, H5S_ALL, H5P_DEFAULT, data)) {
+                printf("Error in H5Dwrite");
+                exit(0);
+            }
+        } else //BIG_ENDIAN_DATA
+        {
+            if (0 > (idsid = H5Dcreate(fid, DATASET, H5T_IEEE_F32BE, sid, H5P_DEFAULT, cpid, H5P_DEFAULT))) {
+                printf("Error in H5Dcreate");
+                exit(0);
+            }
+            if (0 > H5Dwrite(idsid, H5T_IEEE_F32BE, H5S_ALL, H5S_ALL, H5P_DEFAULT, data)) {
+                printf("Error in H5Dwrite");
+                exit(0);
+            }
+        }
+        free(data);
+        if (0 > H5Dclose(idsid)) {
+            printf("Error in H5Dclose");
+            exit(0);
+        };
+    } else if (dataType == ROCCI_DOUBLE) {
+        double *data = malloc(sizeof(double)*nbEle);
+        readfile(oriFilePath, nbEle, sizeof(double), data);
+
+        printf("original data = ");
+        for (i = 0; i < 20; i++)
+            printf("%f ", data[i]);
+        printf("....\n");
+
+        if (dataEndianType == LITTLE_ENDIAN_DATA) {
+            if (0 > (idsid = H5Dcreate(fid, DATASET, H5T_IEEE_F64LE, sid, H5P_DEFAULT, cpid, H5P_DEFAULT))) {
+                printf("Error in H5Dcreate");
+                exit(0);
+            }
+            if (0 > H5Dwrite(idsid, H5T_IEEE_F64LE, H5S_ALL, H5S_ALL, H5P_DEFAULT, data)) {
+                printf("Error in H5Dwrite");
+                exit(0);
+            }
+        } else //BIG_ENDIAN_DATA
+        {
+            if (0 > (idsid = H5Dcreate(fid, DATASET, H5T_IEEE_F64BE, sid, H5P_DEFAULT, cpid, H5P_DEFAULT))) {
+                printf("Error in H5Dcreate");
+                exit(0);
+            }
+            if (0 > H5Dwrite(idsid, H5T_IEEE_F64BE, H5S_ALL, H5S_ALL, H5P_DEFAULT, data)) {
+                printf("Error in H5Dwrite");
+                exit(0);
+            }
+        }
+        free(data);
+        if (0 > H5Dclose(idsid)) {
+            printf("Error in H5Dclose");
+            exit(0);
+        };
+    } else if (dataType == ROCCI_INT8) {
+        int8_t *data =  malloc(sizeof(int8_t)*nbEle);
+        readfile(oriFilePath, nbEle, sizeof(int8_t), data);
+
+        printf("original data = ");
+        for (i = 0; i < 20; i++)
+            printf("%d ", data[i]);
+        printf("....\n");
+
+        if (dataEndianType == LITTLE_ENDIAN_DATA) {
+            if (0 > (idsid = H5Dcreate(fid, DATASET, H5T_STD_I8LE, sid, H5P_DEFAULT, cpid, H5P_DEFAULT))) {
+                printf("Error in H5Dcreate");
+                exit(0);
+            }
+            if (0 > H5Dwrite(idsid, H5T_STD_I8LE, H5S_ALL, H5S_ALL, H5P_DEFAULT, data)) {
+                printf("Error in H5Dwrite");
+                exit(0);
+            }
+        } else //BIG_ENDIAN_DATA
+        {
+            if (0 > (idsid = H5Dcreate(fid, DATASET, H5T_STD_I8BE, sid, H5P_DEFAULT, cpid, H5P_DEFAULT))) {
+                printf("Error in H5Dcreate");
+                exit(0);
+            }
+            if (0 > H5Dwrite(idsid, H5T_STD_I8BE, H5S_ALL, H5S_ALL, H5P_DEFAULT, data)) {
+                printf("Error in H5Dwrite");
+                exit(0);
+            }
+        }
+        free(data);
+        if (0 > H5Dclose(idsid)) {
+            printf("Error in H5Dclose");
+            exit(0);
+        }
+    } else if (dataType == ROCCI_UINT8) {
+        uint8_t *data = malloc(sizeof(uint8_t)*nbEle);
+        readfile(oriFilePath, nbEle, sizeof(uint8_t), data);
+
+        printf("original data = ");
+        for (i = 0; i < 20; i++)
+            printf("%d ", data[i]);
+        printf("....\n");
+
+        if (dataEndianType == LITTLE_ENDIAN_DATA) {
+            if (0 > (idsid = H5Dcreate(fid, DATASET, H5T_STD_U8LE, sid, H5P_DEFAULT, cpid, H5P_DEFAULT))) {
+                printf("Error in H5Dcreate");
+                exit(0);
+            }
+            if (0 > H5Dwrite(idsid, H5T_STD_U8LE, H5S_ALL, H5S_ALL, H5P_DEFAULT, data)) {
+                printf("Error in H5Dwrite");
+                exit(0);
+            }
+        } else //BIG_ENDIAN_DATA
+        {
+            if (0 > (idsid = H5Dcreate(fid, DATASET, H5T_STD_U8BE, sid, H5P_DEFAULT, cpid, H5P_DEFAULT))) {
+                printf("Error in H5Dcreate");
+                exit(0);
+            }
+            if (0 > H5Dwrite(idsid, H5T_STD_U8BE, H5S_ALL, H5S_ALL, H5P_DEFAULT, data)) {
+                printf("Error in H5Dwrite");
+                exit(0);
+            }
+        }
+        free(data);
+        if (0 > H5Dclose(idsid)) {
+            printf("Error in H5Dclose");
+            exit(0);
+        }
+    } else if (dataType == ROCCI_INT16) {
+
+        int16_t *data = malloc(sizeof(int16_t)*nbEle);
+        readfile(oriFilePath, nbEle, sizeof(int16_t), data);
+
+        printf("original data = ");
+        for (i = 0; i < 20; i++)
+            printf("%d ", data[i]);
+        printf("....\n");
+
+        if (dataEndianType == LITTLE_ENDIAN_DATA) {
+            if (0 > (idsid = H5Dcreate(fid, DATASET, H5T_STD_I16LE, sid, H5P_DEFAULT, cpid, H5P_DEFAULT))) {
+                printf("Error in H5Dcreate");
+                exit(0);
+            }
+            if (0 > H5Dwrite(idsid, H5T_STD_I16LE, H5S_ALL, H5S_ALL, H5P_DEFAULT, data)) {
+                printf("Error in H5Dwrite");
+                exit(0);
+            }
+        } else //BIG_ENDIAN_DATA
+        {
+            if (0 > (idsid = H5Dcreate(fid, DATASET, H5T_STD_I16BE, sid, H5P_DEFAULT, cpid, H5P_DEFAULT))) {
+                printf("Error in H5Dcreate");
+                exit(0);
+            }
+            if (0 > H5Dwrite(idsid, H5T_STD_I16BE, H5S_ALL, H5S_ALL, H5P_DEFAULT, data)) {
+                printf("Error in H5Dwrite");
+                exit(0);
+            }
+        }
+        free(data);
+        if (0 > H5Dclose(idsid)) {
+            printf("Error in H5Dclose");
+            exit(0);
+        }
+    } else if (dataType == ROCCI_UINT16) {
+        uint16_t *data = malloc(sizeof(uint16_t)*nbEle);
+        readfile(oriFilePath, nbEle, sizeof(uint16_t), data);
+
+        printf("original data = ");
+        for (i = 0; i < 20; i++)
+            printf("%d ", data[i]);
+        printf("....\n");
+
+        if (dataEndianType == LITTLE_ENDIAN_DATA) {
+            if (0 > (idsid = H5Dcreate(fid, DATASET, H5T_STD_U16LE, sid, H5P_DEFAULT, cpid, H5P_DEFAULT))) {
+                printf("Error in H5Dcreate");
+                exit(0);
+            }
+            if (0 > H5Dwrite(idsid, H5T_STD_U16LE, H5S_ALL, H5S_ALL, H5P_DEFAULT, data)) {
+                printf("Error in H5Dwrite");
+                exit(0);
+            }
+        } else //BIG_ENDIAN_DATA
+        {
+            if (0 > (idsid = H5Dcreate(fid, DATASET, H5T_STD_U16BE, sid, H5P_DEFAULT, cpid, H5P_DEFAULT))) {
+                printf("Error in H5Dcreate");
+                exit(0);
+            }
+            if (0 > H5Dwrite(idsid, H5T_STD_U16BE, H5S_ALL, H5S_ALL, H5P_DEFAULT, data)) {
+                printf("Error in H5Dwrite");
+                exit(0);
+            }
+        }
+        free(data);
+        if (0 > H5Dclose(idsid)) {
+            printf("Error in H5Dclose");
+            exit(0);
+        }
+    } else if (dataType == ROCCI_INT32) {
+        //printf("%i \t %i\n", sizeof(int), sizeof(int32_t));
+        int32_t *data = malloc(sizeof(int32_t)*nbEle);
+        readfile(oriFilePath, nbEle, sizeof(int32_t), data);
+
+        printf("original data = ");
+        for (i = 0; i < 20; i++)
+            printf("%d ", data[i]);
+        printf("....\n");
+
+        if (dataEndianType == LITTLE_ENDIAN_DATA) {
+            if (0 > (idsid = H5Dcreate(fid, DATASET, H5T_STD_I32LE, sid, H5P_DEFAULT, cpid, H5P_DEFAULT))) {
+                printf("Error in H5Dcreate");
+                exit(0);
+            }
+            if (0 > H5Dwrite(idsid, H5T_STD_I32LE, H5S_ALL, H5S_ALL, H5P_DEFAULT, data)) {
+                printf("Error in H5Dwrite");
+                exit(0);
+            }
+        } else //BIG_ENDIAN_DATA
+        {
+            if (0 > (idsid = H5Dcreate(fid, DATASET, H5T_STD_I32BE, sid, H5P_DEFAULT, cpid, H5P_DEFAULT))) {
+                printf("Error in H5Dcreate");
+                exit(0);
+            }
+            if (0 > H5Dwrite(idsid, H5T_STD_I32BE, H5S_ALL, H5S_ALL, H5P_DEFAULT, data)) {
+                printf("Error in H5Dwrite");
+                exit(0);
+            }
+        }
+        free(data);
+        if (0 > H5Dclose(idsid)) {
+            printf("Error in H5Dclose");
+            exit(0);
+        }
+    } else if (dataType == ROCCI_UINT32) {
+        uint32_t *data = malloc(sizeof(uint32_t)*nbEle);
+        readfile(oriFilePath, nbEle, sizeof(uint32_t), data);
+
+        printf("original data = ");
+        for (i = 0; i < 20; i++)
+            printf("%d ", data[i]);
+        printf("....\n");
+
+        if (dataEndianType == LITTLE_ENDIAN_DATA) {
+            if (0 > (idsid = H5Dcreate(fid, DATASET, H5T_STD_U32LE, sid, H5P_DEFAULT, cpid, H5P_DEFAULT))) {
+                printf("Error in H5Dcreate");
+                exit(0);
+            }
+            if (0 > H5Dwrite(idsid, H5T_STD_U32LE, H5S_ALL, H5S_ALL, H5P_DEFAULT, data)) {
+                printf("Error in H5Dwrite");
+                exit(0);
+            }
+        } else //BIG_ENDIAN_DATA
+        {
+            if (0 > (idsid = H5Dcreate(fid, DATASET, H5T_STD_U32BE, sid, H5P_DEFAULT, cpid, H5P_DEFAULT))) {
+                printf("Error in H5Dcreate");
+                exit(0);
+            }
+            if (0 > H5Dwrite(idsid, H5T_STD_U32BE, H5S_ALL, H5S_ALL, H5P_DEFAULT, data)) {
+                printf("Error in H5Dwrite");
+                exit(0);
+            }
+        }
+        free(data);
+        if (0 > H5Dclose(idsid)) {
+            printf("Error in H5Dclose");
+            exit(0);
+        }
+    } else if (dataType == ROCCI_INT64) {
+        int64_t *data = malloc(sizeof(int64_t)*nbEle);
+        readfile(oriFilePath, nbEle, sizeof(int64_t), data);
+
+        printf("original data = ");
+        for (i = 0; i < 20; i++)
+            printf("%ld ", data[i]);
+        printf("....\n");
+
+        if (dataEndianType == LITTLE_ENDIAN_DATA) {
+            if (0 > (idsid = H5Dcreate(fid, DATASET, H5T_STD_I64LE, sid, H5P_DEFAULT, cpid, H5P_DEFAULT))) {
+                printf("Error in H5Dcreate");
+                exit(0);
+            }
+            if (0 > H5Dwrite(idsid, H5T_STD_I64LE, H5S_ALL, H5S_ALL, H5P_DEFAULT, data)) {
+                printf("Error in H5Dwrite");
+                exit(0);
+            }
+        } else //BIG_ENDIAN_DATA
+        {
+            if (0 > (idsid = H5Dcreate(fid, DATASET, H5T_STD_I64BE, sid, H5P_DEFAULT, cpid, H5P_DEFAULT))) {
+                printf("Error in H5Dcreate");
+                exit(0);
+            }
+            if (0 > H5Dwrite(idsid, H5T_STD_I64BE, H5S_ALL, H5S_ALL, H5P_DEFAULT, data)) {
+                printf("Error in H5Dwrite");
+                exit(0);
+            }
+        }
+        free(data);
+        if (0 > H5Dclose(idsid)) {
+            printf("Error in H5Dclose");
+            exit(0);
+        }
+    } else if (dataType == ROCCI_UINT64) {
+        uint64_t *data = malloc(sizeof(uint64_t)*nbEle);
+        readfile(oriFilePath, nbEle, sizeof(uint64_t), data);
+
+        printf("original data = ");
+        for (i = 0; i < 20; i++)
+            printf("%ld ", data[i]);
+        printf("....\n");
+
+        if (dataEndianType == LITTLE_ENDIAN_DATA) {
+            if (0 > (idsid = H5Dcreate(fid, DATASET, H5T_STD_U64LE, sid, H5P_DEFAULT, cpid, H5P_DEFAULT))) {
+                printf("Error in H5Dcreate");
+                exit(0);
+            }
+            if (0 > H5Dwrite(idsid, H5T_STD_U64LE, H5S_ALL, H5S_ALL, H5P_DEFAULT, data)) {
+                printf("Error in H5Dwrite");
+                exit(0);
+            }
+        } else //BIG_ENDIAN_DATA
+        {
+            if (0 > (idsid = H5Dcreate(fid, DATASET, H5T_STD_U64BE, sid, H5P_DEFAULT, cpid, H5P_DEFAULT))) {
+                printf("Error in H5Dcreate");
+                exit(0);
+            }
+            if (0 > H5Dwrite(idsid, H5T_STD_U64BE, H5S_ALL, H5S_ALL, H5P_DEFAULT, data)) {
+                printf("Error in H5Dwrite");
+                exit(0);
+            }
+        }
+        free(data);
+        if (0 > H5Dclose(idsid)) {
+            printf("Error in H5Dclose");
+            exit(0);
+        }
+    } else {
+        printf("Error: unknown data type in sz3ToHDF5.cpp!\n");
+        exit(0);
+    }
+
+    /*Close and release resources*/
+    if (0 > H5Sclose(sid)) {
+        printf("Error in H5Sclose");
+        exit(0);
+    }
+    if (0 > H5Pclose(cpid)) {
+        printf("Error in H5Pclose");
+        exit(0);
+    }
+    if (0 > H5Fclose(fid)) {
+        printf("Error in H5Fclose");
+        exit(0);
+    }
+    free(cd_values);
+    printf("Output hdf5 file: %s\n", outputFilePath);
+    herr_t ret = H5Zunregister(H5Z_FILTER_ROCCI);
+    if (ret < 0) return -1;
+    H5close();
+    return 0;
+}

--- a/test/rocciToHDF5.c
+++ b/test/rocciToHDF5.c
@@ -1,9 +1,9 @@
 /**
- *  @file szToHDF5.c
+ *  @file rocciToHDF5.c
  *  @author Sheng Di
- *  @date July, 2017
+ *  @date Sept, 2023
  *  @brief This is an example of using compression interface (HDF5)
- *  (C) 2017 by Mathematics and Computer Science (MCS), Argonne National Laboratory.
+ *  (C) 2023 by Mathematics and Computer Science (MCS), Argonne National Laboratory.
  *      See COPYRIGHT in top-level directory.
  */
 
@@ -18,7 +18,6 @@
 #define DATASET "testdata_compressed"
 
 
-// using namespace SZ;
 
 dataEndianType = LITTLE_ENDIAN_DATA;
 
@@ -35,6 +34,8 @@ int main(int argc, char *argv[]) {
     size_t cd_nelmts, nbEle;
     unsigned int *cd_values = NULL;
     //unsigned int cd_values[7];
+
+    cd_nelmts = 0;
 
     herr_t status;
     htri_t avail;
@@ -73,11 +74,10 @@ int main(int argc, char *argv[]) {
     else if (strcmp(argv[1], "-u64") == 0)
         dataType = ROCCI_UINT64;
     else {
-        printf("Error: unknown data type in sz3ToHDF5.c!\n");
+        printf("Error: unknown data type in rocciToHDF5.c!\n");
         exit(0);
     }
 
-    printf("DTYPE: %i", dataType);
     snprintf(oriFilePath, 640, "%s", argv[2]);
     if (argc >= 4) {
         r1 = atoi(argv[3]); //8
@@ -101,7 +101,7 @@ int main(int argc, char *argv[]) {
     interp_algo = 1;
 
     //printf("cfgFile=%s\n", cfgFile);
-    snprintf(outputFilePath, 640, "%s.sz3.h5", oriFilePath);
+    snprintf(outputFilePath, 640, "%s.rocci.h5", oriFilePath);
 
 //	printf("argv[1]=%s, dataType=%d\n", argv[1], dataType);
     nbEle = computeDataLength(r5, r4, r3, r2, r1);
@@ -110,20 +110,11 @@ int main(int argc, char *argv[]) {
 
     //Create cd_values
     printf("Dimension sizes: n5=%u, n4=%u, n3=%u, n2=%u, n1=%u\n", r5, r4, r3, r2, r1);
-    int mode = 1; //0: ABS, 1: REL, ...
-    ROCCI_errConfigToCdArray(&cd_nelmts, &cd_values, mode, 0.001, 0.001, 0,
-                          0, 60.0); //SZ_FLOAT or SZ_DOUBLE or SZ_INT 100x500x500 : 0, 0, 100, 500, 500, ABS, REL (0.01, 0.01*(max-min), PW_REL (0.01, 5, 6, 7, 8, 9 --> 5*0.01, 6*0.01, ...), PSNR (mean squared error)).
-    //load_conffile_flag = 0;
-    //										 REL
-    //SZ_metaDataErrToCdArray(&cd_nelmts, &cd_values, dataType, r5, r4, r3, r2, r1, 1, 0.01, 0.01, 0, 0); //SZ_FLOAT or SZ_DOUBLE or SZ_INT 100x500x500 : 0, 0, 100, 500, 500, ABS, REL (0.01, 0.01*(max-min), PW_REL (0.01, 5, 6, 7, 8, 9 --> 5*0.01, 6*0.01, ...), PSNR (mean squared error)).
-    /*cd_nelmts = 5;
-    cd_values[0] = 3;
-    cd_values[1] = 0;
-    cd_values[2] = 128;
-    cd_values[3] = 8;
-    cd_values[4] = 8;
-    cd_values[5] = 0;
-    cd_values[6] = 0;*/
+    // int mode = 1; //0: ABS, 1: REL, ...
+    cd_values = (unsigned int*)malloc(sizeof(unsigned int)*11);
+    // ROCCI_copymetaDataToCdArray(&cd_nelmts, cd_values, dataType, r5, r4, r3, r2, r1);
+    // ROCCI_errConfigToCdArray(&cd_nelmts, &cd_values, mode, 0.001, 0.001, 0,
+    //                       0, 60.0);
 
     int i = 0;
 	for(i=0;i<cd_nelmts;i++)
@@ -153,7 +144,7 @@ int main(int argc, char *argv[]) {
         exit(0);
     }
 
-    /* Add the SZ compression filter and set the chunk size */
+    /* Add the ROCCI compression filter and set the chunk size */
     if (0 > H5Pset_filter(cpid, H5Z_FILTER_ROCCI, H5Z_FLAG_MANDATORY, cd_nelmts, cd_values)) {
         printf("Error in H5Psetfilter");
         exit(0);
@@ -163,7 +154,7 @@ int main(int argc, char *argv[]) {
         status = H5Zget_filter_info(H5Z_FILTER_ROCCI, &filter_config);
 
         if (filter_config & H5Z_FILTER_CONFIG_ENCODE_ENABLED)
-            printf("sz filter is available for encoding and decoding.\n");
+            printf("ROCCI filter is available for encoding and decoding.\n");
     }
     else{
         printf("ROCCI filter not available, make sure to set HDF5_PLUGIN_PATH\n");
@@ -174,16 +165,7 @@ int main(int argc, char *argv[]) {
         exit(0);
     }
 
-    //Initialize the configuration for SZ
-    //You can also use the global variable conf_params to set the configuration for sz without cfgFile.
-    //Example of setting an absolute error bound:
-    //			sz_params* params = H5Z_SZ_Init_Default();
-    //			params->errorBoundMode = ABS;
-    //			params->absErrBound = 1E-4;
-
-    //H5Z_SZ_Init(cfgFile);
-
-    printf("....Writing SZ compressed data.............\n");
+    printf("....Writing ROCCI compressed data.............\n");
 
     if (dataType == ROCCI_FLOAT) {
         float *data = malloc(sizeof(float)*nbEle);
@@ -528,7 +510,7 @@ int main(int argc, char *argv[]) {
             exit(0);
         }
     } else {
-        printf("Error: unknown data type in sz3ToHDF5.cpp!\n");
+        printf("Error: unknown data type in rocciToHDF5.cpp!\n");
         exit(0);
     }
 


### PR DESCRIPTION
This PR allows for basic configuration, compression and decompression using the C API and h5repack/h5dump. This requires keeping `rocci.config` in the working directory as we need to have access to the configuration to determine which compressor we used for compression - which we may choose to include as metadata somehow in the resulting h5 file.